### PR TITLE
toJson function is updated for ValueTables of signals

### DIFF
--- a/FundTree/src/browser/dbc/Dbc.ts
+++ b/FundTree/src/browser/dbc/Dbc.ts
@@ -618,10 +618,18 @@ class Dbc {
    * @returns JSON representation of loaded DBC data
    */
   toJson(options?: { pretty?: boolean; preserveFormat?: boolean }) {
+	  
     const replacer = (key: any, value: any) => {
       if (value instanceof Map) {
         if (key === 'valueTable' || key === 'valueTables') {
-          return Object.fromEntries(value.entries());
+			const jsonArray = [];
+			
+			for (const [key, val] of value.entries()) {
+  			  jsonArray.push({ key, value: val });
+  			}
+  
+			return jsonArray;
+          //return Object.fromEntries(value.entries());
         }
         return Array.from(value.values()); // or with spread: value: [...value]
       } else {

--- a/FundTree/src/browser/dbcWdgt/dbc-file-command.ts
+++ b/FundTree/src/browser/dbcWdgt/dbc-file-command.ts
@@ -202,26 +202,22 @@ const defaultRawData ={
           ],
           "unit": "",
           "valueTable": [
-			  {
-				  "valueName": "0",
-				  "valueDesc": "Empty"
-			  },
-			  {
-				  "valueName": "1",
-				  "valueDesc": "Half"
-			  },
-			  {
-				  "valueName": "2",
-				  "valueDesc": "Quarter"
-			  },
-			  {
-				  "valueName": "3",
-				  "valueDesc": "Full"
-			  },
-			  {
-				  "valueName": "4",
-				  "valueDesc": "notEnabled"
-			  }
+            {
+              "key": 3,
+              "value": "Notvalid"
+            },
+            {
+              "key": 2,
+              "value": "EmptyOfPwdsThsSttIndctsThtCmpnn"
+            },
+            {
+              "key": 1,
+              "value": "FullofPwds"
+            },
+            {
+              "key": 0,
+              "value": "OkThsSttIndctsThtRqWsSccssfllyP"
+            }
           ],
           "description": null,
           "attributes": [],
@@ -276,7 +272,24 @@ const defaultRawData ={
             "Node2"
           ],
           "unit": "%",
-          "valueTable": null,
+          "valueTable": [
+            {
+              "key": 3,
+              "value": "NotAvailable"
+            },
+            {
+              "key": 2,
+              "value": "Error"
+            },
+            {
+              "key": 1,
+              "value": "RandomNumberIsPresent"
+            },
+            {
+              "key": 0,
+              "value": "RandomNumberIsNotPresent"
+            }
+          ],
           "description": null,
           "attributes": [],
           "dataType": "uint32"
@@ -298,12 +311,24 @@ const defaultRawData ={
             "Node2"
           ],
           "unit": "",
-		  "valueTable": {
-            "0": "notAcive",
-            "1": "active",
-            "2": "reservedForSAEAssignment",
-            "3": "notAvaliable"
-          },
+          "valueTable": [
+            {
+              "key": 3,
+              "value": "NotDefined"
+            },
+            {
+              "key": 2,
+              "value": "BlckdThsSttIndctsThtALckUnlckCm"
+            },
+            {
+              "key": 1,
+              "value": "LckdThsSttIndctsThtCmpnntCnNOTB"
+            },
+            {
+              "key": 0,
+              "value": "UnlckdThsSttIndctsThtCmpnntCnBS"
+            }
+          ],
           "description": "First signal in this message",
           "attributes": [
             {

--- a/FundTree/src/browser/dbcWdgt/dbc-schema.ts
+++ b/FundTree/src/browser/dbcWdgt/dbc-schema.ts
@@ -140,11 +140,6 @@ export const signalsView = {
               "type": "Control",
               "label": 'Maximum:', 
               "scope": "#/properties/max"
-            },
-            {
-              "type": "Control",
-              "label": 'Value Table:', 
-              "scope": "#/properties/valueTable"
             }
       ]
     },
@@ -248,18 +243,16 @@ export const dbcSchema = {
     "multiplexer": { "type": "boolean" },
     "receivingNodes": { "type": "array", "items": { "type": "string" } },
     "unit": { "type": "string" },
-    "valueTable": {
-      "type": "array",
-      "items":{
-	  "type": "object",   
-	   "properties": {
-		   "valueName": { "type": "string", "title": "Value" },
-		   "valueDesc": { "type": "string", "title": "Description" }
-       }
-      },
-	 'additionalProperties': false,     
+	"valueTable":{
+		"type": "array",
+		"items": {
+			"type":"object",
+			"properties": {
+				"key": { "type": "number", "title": "Value" },
+				"value": { "type": "string" , "title": "Description"}
+			}
+		}
 	},
-	
     "description": { "type": ["string", "null"] },
     "attributes": {
       "type": "array",


### PR DESCRIPTION
new format is below.
"valueTable": [
            {
              "key": 3,
              "value": "Notvalid"
            },
            {
              "key": 2,
              "value": "EmptyOfPwdsThsSttIndctsThtCmpnn"
            },
            {
              "key": 1,
              "value": "FullofPwds"
            },
            {
              "key": 0,
              "value": "OkThsSttIndctsThtRqWsSccssfllyP"
            }
          ],

Older format output:
[{"1":"Value One"},{"2":"Value Two"},{"3":"Value Three"}]